### PR TITLE
Update BookStack v23.06.2 (as of today) for TKL18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-PHP_EXTRA_PINS=libpcre2-8-0 libgd3
-PHP_VERSION=8.1
-
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey/laravel.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 turnkey-bookstack-18 (1) turnkey; urgency=low
 
-  * Install latest upstream version of BookStack: x.y.z (as of today, automatically searches for the revision).
+  * Install latest upstream version of BookStack: v23.06.2 (as of today, automatically searches for the revision).
 
   * Re-build on TurnKey Linux 18 (Debian 12 'bookworm')
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-bookstack-18 (1) turnkey; urgency=low
+
+  * Install latest upstream version of BookStack: x.y.z (as of today, automatically searches for the revision).
+
+  * Re-build on TurnKey Linux 18 (Debian 12 'bookworm')
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Daniele Lolli <github@uncledan.it>  Tue, 3 Aug 2023 19:00:00 +0200
+
 turnkey-bookstack-17.2 (1) turnkey; urgency=low
 
   * Update BookStack to latest stable: v23.01.1.

--- a/plan/main
+++ b/plan/main
@@ -1,8 +1,9 @@
 #include <turnkey/base>
-#include <turnkey/lamp81>
+#include <turnkey/lamp>
 
 python3-bcrypt
-php8.1-xml
-php8.1-curl
-php8.1-gd
-php8.1-mbstring
+php-xml
+php-curl
+php-gd
+php-mbstring
+libapache2-mod-security2


### PR DESCRIPTION
Minor tweaks, removed PHP pin.